### PR TITLE
serializers.py: Pass complete token to parse_token

### DIFF
--- a/rest_auth/registration/serializers.py
+++ b/rest_auth/registration/serializers.py
@@ -115,7 +115,7 @@ class SocialLoginSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 _("Incorrect input. access_token or code is required."))
 
-        social_token = adapter.parse_token({'access_token': access_token})
+        social_token = adapter.parse_token(token)
         social_token.app = app
 
         try:


### PR DESCRIPTION
The parse_token method in django-allauth extracts the refresh_token and expires_in time from the returned access token. This fix passes the complete token to the parse_token method instead of stripping out just the access_token portion of it (which was preventing the refresh token from being saved previously)